### PR TITLE
Allow public clients to use loopback ipv4 too, go upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye AS build
+FROM golang:1.22-bookworm AS build
 
 WORKDIR /src
 
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN go install ./...
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 WORKDIR /app
 

--- a/clients.go
+++ b/clients.go
@@ -10,12 +10,12 @@ import (
 
 var (
 	// reValidPublicRedirectUri is a fairly strict regular expression that must
-	// match against the redirect URI for a 'public' client. It intentionally may
+	// match against the redirect URI for a Public client. It intentionally may
 	// not match all URLs that are technically valid, but is it meant to match
 	// all commonly constructed ones, without inadvertently falling victim to
 	// parser bugs or parser inconsistencies (e.g.,
 	// https://www.blackhat.com/docs/us-17/thursday/us-17-Tsai-A-New-Era-Of-SSRF-Exploiting-URL-Parser-In-Trending-Programming-Languages.pdf)
-	reValidPublicRedirectURI = regexp.MustCompile(`\Ahttp://localhost(?::[0-9]{1,5})?(?:|/[A-Za-z0-9./_-]{0,1000})\z`)
+	reValidPublicRedirectURI = regexp.MustCompile(`\Ahttp://(?:localhost|127\.0\.0\.1)(?::[0-9]{1,5})?(?:|/[A-Za-z0-9./_-]{0,1000})\z`)
 )
 
 type Client struct {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/lstoll/webauthn-oidc-idp
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	github.com/aws/aws-sdk-go v1.36.24
 	github.com/duo-labs/webauthn v0.0.0-20220330035159-03696f3d4499

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lstoll/webauthn-oidc-idp
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.36.24


### PR DESCRIPTION
In lstoll/oidc we use 127.0.0.1 to avoid hosts files or other binding issues, make our public redirect URI validation handle this too.

Upgrade the go.mod/Docker to latest Go and Debian while at it.