### PR TITLE
Run golangci-lint in CI, fix a couple issues 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Set up Go
@@ -27,6 +27,11 @@ jobs:
     - name: Test
       run: |
         go test ./...
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: latest
 
     - name: Docker meta
       id: meta

--- a/server.go
+++ b/server.go
@@ -163,7 +163,7 @@ func (s *oidcServer) startLogin(rw http.ResponseWriter, req *http.Request) {
 
 	requestOptions := protocol.PublicKeyCredentialRequestOptions{
 		Challenge:        challenge,
-		Timeout:          s.webauthn.Config.Timeout,
+		Timeout:          int(s.webauthn.Config.Timeouts.Login.Timeout),
 		RelyingPartyID:   s.webauthn.Config.RPID,
 		UserVerification: s.webauthn.Config.AuthenticatorSelection.UserVerification,
 		// AllowedCredentials: allowedCredentials, // this is what we don't send for resident/usernameless

--- a/webauthn_manager.go
+++ b/webauthn_manager.go
@@ -391,7 +391,7 @@ func (w *webauthnManager) execTemplate(rw http.ResponseWriter, r *http.Request, 
 		"csrfField": func() template.HTML {
 			return template.HTML(fmt.Sprintf(`<input type="hidden" name="csrf_token" value="%s">`, nosurf.Token(r)))
 		},
-		"pathFor": func(s string) string {
+		"pathFor": func(_ string) string {
 			return "TODO"
 		},
 	}


### PR DESCRIPTION
We weren't running it there, making it less useful. So run it. Fix a nit and a deprecation  it found.
