### PR TITLE
reload database after user registration

### DIFF
--- a/db.go
+++ b/db.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"sync"
 
 	"crawshaw.dev/jsonfile"
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -173,14 +174,40 @@ func openDB(path string) (*DB, error) {
 	if ver != schemaVersion {
 		return nil, fmt.Errorf("unsupported database version: %d", ver)
 	}
-	return &DB{f: f}, nil
+	return &DB{unsafeF: f, path: path}, nil
 }
 
 // DB is the IDP database.
 // The database consists of a single JSON file stored on disk.
 // It contains unencrypted private key material.
 type DB struct {
-	f *jsonfile.JSONFile[schema]
+	unsafeF *jsonfile.JSONFile[schema] // unsafe, use f() to access.
+	path    string                     // path of the file on disk.
+	mu      sync.RWMutex               // protects unsafeF.
+}
+
+func (db *DB) f() *jsonfile.JSONFile[schema] {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	return db.unsafeF
+}
+
+func (db *DB) Reload() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	file, err := jsonfile.Load[schema](db.path)
+	if err != nil {
+		return err
+	}
+
+	var ver uint
+	file.Read(func(db *schema) { ver = db.Version })
+	if ver != schemaVersion {
+		return fmt.Errorf("unsupported database version: %d", ver)
+	}
+	db.unsafeF = file
+	return nil
 }
 
 func (db *DB) GetUserByID(userID string) (User, error) {
@@ -188,7 +215,7 @@ func (db *DB) GetUserByID(userID string) (User, error) {
 		v  User
 		ok bool
 	)
-	db.f.Read(func(db *schema) {
+	db.f().Read(func(db *schema) {
 		v, ok = db.Users[userID]
 	})
 	if !ok {
@@ -218,7 +245,7 @@ func (db *DB) CreateUser(user User) (User, error) {
 	user.ID = uuid.NewString()
 	user.EnrollmentKey = uuid.NewString()
 	user.Credentials = make(map[string]webauthn.Credential)
-	err := db.f.Write(func(db *schema) error {
+	err := db.f().Write(func(db *schema) error {
 		if _, ok := db.Users[user.ID]; ok {
 			panic("generated UUID already in use")
 		}
@@ -248,7 +275,7 @@ func (db *DB) UpdateUser(user User) error {
 	if user.ID == "" {
 		return errors.New("user ID missing")
 	}
-	err := db.f.Write(func(db *schema) error {
+	err := db.f().Write(func(db *schema) error {
 		if _, ok := db.Users[user.ID]; !ok {
 			return ErrUserNotFound
 		}
@@ -264,7 +291,7 @@ func (db *DB) UpdateUser(user User) error {
 }
 
 func (db *DB) UpdateUserCredential(userID string, cred webauthn.Credential) error {
-	err := db.f.Write(func(db *schema) error {
+	err := db.f().Write(func(db *schema) error {
 		user, ok := db.Users[userID]
 		if !ok {
 			return ErrUserNotFound
@@ -281,7 +308,7 @@ func (db *DB) UpdateUserCredential(userID string, cred webauthn.Credential) erro
 }
 
 func (db *DB) CreateUserCredential(userID, name string, cred webauthn.Credential) error {
-	err := db.f.Write(func(db *schema) error {
+	err := db.f().Write(func(db *schema) error {
 		if _, ok := db.Users[userID]; !ok {
 			return ErrUserNotFound
 		}
@@ -292,7 +319,7 @@ func (db *DB) CreateUserCredential(userID, name string, cred webauthn.Credential
 }
 
 func (db *DB) DeleteUserCredential(userID string, name string) error {
-	err := db.f.Write(func(db *schema) error {
+	err := db.f().Write(func(db *schema) error {
 		if _, ok := db.Users[userID]; !ok {
 			return ErrUserNotFound
 		}
@@ -304,7 +331,7 @@ func (db *DB) DeleteUserCredential(userID string, name string) error {
 
 func (db *DB) ListUsers() []User {
 	var users []User
-	db.f.Read(func(db *schema) {
+	db.f().Read(func(db *schema) {
 		for _, v := range db.Users {
 			users = append(users, v)
 		}
@@ -313,7 +340,7 @@ func (db *DB) ListUsers() []User {
 }
 
 func (db *DB) Authenticate(sessionID string, auth AuthenticatedUser) error {
-	return db.f.Write(func(db *schema) error {
+	return db.f().Write(func(db *schema) error {
 		if len(db.AuthenticatedUsers) == 0 {
 			db.AuthenticatedUsers = make(map[string]AuthenticatedUser)
 		}
@@ -327,7 +354,7 @@ func (db *DB) GetAuthenticatedUser(sessionID string) (AuthenticatedUser, error) 
 		v  AuthenticatedUser
 		ok bool
 	)
-	db.f.Read(func(db *schema) {
+	db.f().Read(func(db *schema) {
 		v, ok = db.AuthenticatedUsers[sessionID]
 	})
 	if !ok {
@@ -338,7 +365,7 @@ func (db *DB) GetAuthenticatedUser(sessionID string) (AuthenticatedUser, error) 
 
 func (db *DB) Signer() core.Signer {
 	var v RSAKey
-	db.f.Read(func(db *schema) {
+	db.f().Read(func(db *schema) {
 		v = db.OIDCSigningKey
 	})
 	if v.KeyID == "" {
@@ -349,7 +376,7 @@ func (db *DB) Signer() core.Signer {
 
 func (db *DB) KeySource() discovery.KeySource {
 	var v RSAKey
-	db.f.Read(func(db *schema) {
+	db.f().Read(func(db *schema) {
 		v = db.OIDCSigningKey
 	})
 	if v.KeyID == "" {
@@ -359,7 +386,7 @@ func (db *DB) KeySource() discovery.KeySource {
 }
 
 func (db *DB) SessionManager() core.SessionManager {
-	return &sessionManager{f: db.f}
+	return &sessionManager{f: db.f()}
 }
 
 const rsaKeyBits = 2048
@@ -412,7 +439,7 @@ func migrateSQLToJSON(sqldb *storage, jsondb *DB) error {
 // createMigratedUser saves the given user as is in the database.
 // Do not use; it's temporary and will be deleted in the near future.
 func (db *DB) createMigratedUser(user User) error {
-	return db.f.Write(func(db *schema) error {
+	return db.f().Write(func(db *schema) error {
 		if len(db.Users) == 0 {
 			db.Users = make(map[string]User)
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -31,6 +31,34 @@ func TestOpenDB(t *testing.T) {
 	}
 }
 
+func TestReloadDB(t *testing.T) {
+	t.Parallel()
+
+	file := filepath.Join(t.TempDir(), "db.json")
+
+	db, err := openDB(file)
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+
+	if want, got := 0, len(db.ListUsers()); got != want {
+		t.Fatalf("want %d users, got: %d", want, got)
+	}
+
+	err = os.WriteFile(file, []byte(`{"version": 1, "users": {"uuid": {"id": "uuid"}}}`), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := db.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if want, got := 1, len(db.ListUsers()); got != want {
+		t.Fatalf("want %d users after reload, got: %d", want, got)
+	}
+}
+
 func TestUsers(t *testing.T) {
 	t.Parallel()
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -116,6 +116,9 @@ func TestE2E(t *testing.T) {
 		t.Fatal("server startup timed out")
 	}
 
+	// not strictly needed for the E2E tests.
+	reloadDB(net.JoinHostPort("localhost", port))
+
 	/* enable the virtual webauthn environment */
 	var virtAuthenticatorID cdpwebauthn.AuthenticatorID
 

--- a/go.mod
+++ b/go.mod
@@ -40,3 +40,5 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
+
+replace crawshaw.dev/jsonfile => github.com/sr/jsonfile v0.0.0-20240301210704-69e8a5b5b148

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-crawshaw.dev/jsonfile v0.0.0-20240206193014-699d1dad804e h1:6uFwG2+DRyGcpVzlXMRCP/8DX7jKwTq1jQRFsdbWmU0=
-crawshaw.dev/jsonfile v0.0.0-20240206193014-699d1dad804e/go.mod h1:rWYpwcta+HEXjFjbDiSFGqzhZ5KPlNhit+irVCFLQAI=
 github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732 h1:XYUCaZrW8ckGWlCRJKCSoh/iFwlpX316a8yY9IFEzv8=
 github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
 github.com/chromedp/chromedp v0.9.5 h1:viASzruPJOiThk7c5bueOUY91jGLJVximoEMGoH93rg=
@@ -67,6 +65,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sr/jsonfile v0.0.0-20240301210704-69e8a5b5b148 h1:gQ7t2Q9iRRtBYAvcszOA9vFGdtW3R/4pT+itPH8b22c=
+github.com/sr/jsonfile v0.0.0-20240301210704-69e8a5b5b148/go.mod h1:rWYpwcta+HEXjFjbDiSFGqzhZ5KPlNhit+irVCFLQAI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
This makes the CLI tell the server to reloads the database after a user is registered and activated via a HTTP handler on loopback. This is mostly a UX thing to make the registration flow smoother. In the first commit I went with a double mutex, then decided to implement reloading directly in jsonfile itself, which is slightly cleaner.