### PR TITLE
Credential addition via CLI

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"os"
@@ -163,8 +162,6 @@ func TestE2E(t *testing.T) {
 			t.Fatal(err)
 		}
 		ep := registrationURL(issConfig.URL, user)
-
-		log.Printf("ep: %v", ep)
 
 		runErrC := make(chan error, 1)
 		doneC := make(chan struct{}, 1)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -163,6 +164,8 @@ func TestE2E(t *testing.T) {
 		}
 		ep := registrationURL(issConfig.URL, user)
 
+		log.Printf("ep: %v", ep)
+
 		runErrC := make(chan error, 1)
 		doneC := make(chan struct{}, 1)
 		go func() {
@@ -196,13 +199,7 @@ func TestE2E(t *testing.T) {
 		case <-doneC:
 		}
 
-		// we need to mark the user as active for their credentials to be
-		// usable.
-		if err := activateUser(db, user.ID); err != nil {
-			t.Fatal(err)
-		}
-
-		user, err = db.GetActivatedUserByID(user.ID)
+		user, err = db.GetUserByID(user.ID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/google/uuid"
 	"github.com/lstoll/cookiesession"
 	"github.com/lstoll/oidc/core"
 	"github.com/lstoll/oidc/discovery"
@@ -36,8 +37,9 @@ func main() {
 	enroll := flag.Bool("enroll", false, "Enroll a user into the system.")
 	email := flag.String("email", "", "Email address for the user.")
 	fullname := flag.String("fullname", "", "Full name of the user.")
-	activate := flag.Bool("activate", false, "Activate an enrolled user.")
-	userID := flag.String("user-id", "", "ID of user to activate.")
+	addCredential := flag.Bool("add-credential", false, "Generate a new credential enrollment URL for a user")
+	userID := flag.String("user-id", "", "ID of user add credential to.")
+	listCredential := flag.Bool("list-credentials", false, "List credentials for the user-id")
 
 	flag.Parse()
 
@@ -82,9 +84,8 @@ func main() {
 		}
 
 		user, err := db.CreateUser(User{
-			Email:     *email,
-			FullName:  *fullname,
-			Activated: false,
+			Email:    *email,
+			FullName: *fullname,
 		})
 		if err != nil {
 			fatalf("create user: %v", err)
@@ -92,14 +93,45 @@ func main() {
 		reloadDB(*addr)
 		fmt.Printf("Enroll at: %s\n", registrationURL(cfg.Issuer[0].URL, user))
 		return
-	} else if *activate {
+	} else if *addCredential {
 		if *userID == "" {
 			fatal("required flag missing: user-id")
 		}
-		if err := activateUser(db, *userID); err != nil {
-			fatalf("ativate user: %v", err)
+		user, err := db.GetUserByID(*userID)
+		if err != nil {
+			fatalf("get user %s: %w", userID, err)
 		}
+
+		user.EnrollmentKey = uuid.NewString()
+
+		if err := db.UpdateUser(user); err != nil {
+			fatalf("update user %s: %w", userID, err)
+		}
+
 		reloadDB(*addr)
+		fmt.Printf("Enroll at: %s\n", registrationURL(cfg.Issuer[0].URL, user))
+		return
+	} else if *listCredential {
+		if *userID == "" {
+			fatal("required flag missing: user-id")
+		}
+		user, err := db.GetUserByID(*userID)
+		if err != nil {
+			fatalf("get user %s: %w", userID, err)
+		}
+
+		for _, c := range user.Credentials {
+			fmt.Printf("credential: %s (added at %s)\n", c.Name, c.AddedAt)
+		}
+
+		user.EnrollmentKey = uuid.NewString()
+
+		if err := db.UpdateUser(user); err != nil {
+			fatalf("update user %s: %w", userID, err)
+		}
+
+		reloadDB(*addr)
+		fmt.Printf("Enroll at: %s\n", registrationURL(cfg.Issuer[0].URL, user))
 		return
 	}
 
@@ -291,26 +323,6 @@ func registrationURL(iss *url.URL, user User) *url.URL {
 	q.Add("enrollment_token", user.EnrollmentKey)
 	u2.RawQuery = q.Encode()
 	return u2
-}
-
-// activateUser marks the user as activated and deletes its enrollment key.
-// Must be called after the user has completed the registration flow.
-func activateUser(db *DB, userID string) error {
-	user, err := db.GetUserByID(userID)
-	if err != nil {
-		return fmt.Errorf("get user %s: %w", userID, err)
-	}
-
-	user.EnrollmentKey = ""
-	user.Activated = true
-
-	if err := db.UpdateUser(user); err != nil {
-		return fmt.Errorf("update user %s: %w", userID, err)
-	}
-
-	fmt.Println("Done.")
-
-	return nil
 }
 
 // reloadDB tells the server running on addr to reload its database from disk.

--- a/main.go
+++ b/main.go
@@ -123,15 +123,6 @@ func main() {
 		for _, c := range user.Credentials {
 			fmt.Printf("credential: %s (added at %s)\n", c.Name, c.AddedAt)
 		}
-
-		user.EnrollmentKey = uuid.NewString()
-
-		if err := db.UpdateUser(user); err != nil {
-			fatalf("update user %s: %w", userID, err)
-		}
-
-		reloadDB(*addr)
-		fmt.Printf("Enroll at: %s\n", registrationURL(cfg.Issuer[0].URL, user))
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	email := flag.String("email", "", "Email address for the user.")
 	fullname := flag.String("fullname", "", "Full name of the user.")
 	addCredential := flag.Bool("add-credential", false, "Generate a new credential enrollment URL for a user")
-	userID := flag.String("user-id", "", "ID of user add credential to.")
+	userID := flag.String("user-id", "", "ID of user to add credential to.")
 	listCredential := flag.Bool("list-credentials", false, "List credentials for the user-id")
 
 	flag.Parse()

--- a/server.go
+++ b/server.go
@@ -171,7 +171,7 @@ func (s *oidcServer) finishLogin(rw http.ResponseWriter, req *http.Request) {
 
 	userID := string(parsedResponse.Response.UserHandle) // user handle is the webauthn.User#ID we registered with
 
-	user, err := s.db.GetActivatedUserByID(userID)
+	user, err := s.db.GetUserByID(userID)
 	if err != nil {
 		s.httpErr(rw, err)
 		return
@@ -247,7 +247,7 @@ func (s *oidcServer) loggedIn(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	user, err := s.db.GetActivatedUserByID(authdUser.UserID)
+	user, err := s.db.GetUserByID(authdUser.UserID)
 	if err != nil {
 		s.httpErr(rw, err)
 		return


### PR DESCRIPTION
Remove the "Activation" concept. For what we're doing, a unique user ID and enrollment key combo is fine.

Add the ability to add new enrollment keys to users, to add new keys.

Track some more info about the key in the database.