### PR TITLE
A few deployment fixes

### DIFF
--- a/cmd/schemagen-idp/main.go
+++ b/cmd/schemagen-idp/main.go
@@ -20,7 +20,7 @@ func main() {
 	outputFile := os.Args[1]
 
 	slog.Info("schemagen-idp running migrations")
-	dbConn, err := sql.Open("sqlite3", ":memory:")
+	dbConn, err := sql.Open("sqlite3", "file:test.db?mode=memory&cache=shared")
 	if err != nil {
 		slog.Error("failed to open database", "error", err)
 		os.Exit(1)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -117,7 +117,7 @@ func TestE2E(t *testing.T) {
 	serveCtx, serveCancel := context.WithCancel(context.Background())
 	t.Cleanup(serveCancel)
 
-	sqldb, err := sql.Open("sqlite3", ":memory:")
+	sqldb, err := sql.Open("sqlite3", "file:test.db?mode=memory&cache=shared")
 	if err != nil {
 		t.Fatalf("open in-memory database: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lstoll/oidc v1.0.0-alpha.1.0.20240324163255-989e22bde1f1
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
-	github.com/lstoll/web v0.0.0-20250628233112-c8117c2a01a1
+	github.com/lstoll/web v0.0.0-20250706222713-619669e82ecc
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lstoll/oidc v1.0.0-alpha.1.0.20240324163255-989e22bde1f1
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
-	github.com/lstoll/web v0.0.0-20250626220328-c73bfcffd053
+	github.com/lstoll/web v0.0.0-20250628233112-c8117c2a01a1
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lstoll/oidc v1.0.0-alpha.1.0.20240324163255-989e22bde1f1
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
-	github.com/lstoll/web v0.0.0-20250706222713-619669e82ecc
+	github.com/lstoll/web v0.0.0-20250706225620-2a7065af9498
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,10 @@ github.com/lstoll/web v0.0.0-20250626220328-c73bfcffd053 h1:TbORmcM9cGxKvvj1sQaG
 github.com/lstoll/web v0.0.0-20250626220328-c73bfcffd053/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
 github.com/lstoll/web v0.0.0-20250628233112-c8117c2a01a1 h1:IgE06ErgpgOXKu6pD2THyGbIbwrhqaTten02QkPQL1w=
 github.com/lstoll/web v0.0.0-20250628233112-c8117c2a01a1/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
+github.com/lstoll/web v0.0.0-20250706214213-6f1a5d4c9be1 h1:T3PKsvQNIf8QRi6psQwi0gAi5KZDIZ+3QrHDJj/XqEo=
+github.com/lstoll/web v0.0.0-20250706214213-6f1a5d4c9be1/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
+github.com/lstoll/web v0.0.0-20250706222713-619669e82ecc h1:7nZFSSsQXw6y6zPYuRNfdIIuXmRN+SepkV28flUmG2Q=
+github.com/lstoll/web v0.0.0-20250706222713-619669e82ecc/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/lstoll/web v0.0.0-20250706214213-6f1a5d4c9be1 h1:T3PKsvQNIf8QRi6psQwi
 github.com/lstoll/web v0.0.0-20250706214213-6f1a5d4c9be1/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
 github.com/lstoll/web v0.0.0-20250706222713-619669e82ecc h1:7nZFSSsQXw6y6zPYuRNfdIIuXmRN+SepkV28flUmG2Q=
 github.com/lstoll/web v0.0.0-20250706222713-619669e82ecc/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
+github.com/lstoll/web v0.0.0-20250706225620-2a7065af9498 h1:zg9x4HxUIYa8V0VUMRoHmWJhq+I0FpM3G7V26FO0+Mg=
+github.com/lstoll/web v0.0.0-20250706225620-2a7065af9498/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215 h1:fj/z3BLXwgBJ9
 github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215/go.mod h1:x9r6po7qyhQIvVUZSQjs0VwsCfR1sgg9xAPpvyPkfGE=
 github.com/lstoll/web v0.0.0-20250626220328-c73bfcffd053 h1:TbORmcM9cGxKvvj1sQaG37RtykLsS+zaA3Y6lRGT7ws=
 github.com/lstoll/web v0.0.0-20250626220328-c73bfcffd053/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
+github.com/lstoll/web v0.0.0-20250628233112-c8117c2a01a1 h1:IgE06ErgpgOXKu6pD2THyGbIbwrhqaTten02QkPQL1w=
+github.com/lstoll/web v0.0.0-20250628233112-c8117c2a01a1/go.mod h1:7KkvIfjA0uiTZehpOuBA4QNH0PCDwdoYLo8HpWVbG18=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/internal/idp/datamigration_test.go
+++ b/internal/idp/datamigration_test.go
@@ -29,7 +29,7 @@ func TestMigrateData(t *testing.T) {
 		t.Fatalf("failed to open file db: %v", err)
 	}
 
-	sqldb, err := sql.Open("sqlite3", ":memory:")
+	sqldb, err := sql.Open("sqlite3", "file:test.db?mode=memory&cache=shared")
 	if err != nil {
 		t.Fatalf("failed to open sqlite db: %v", err)
 	}

--- a/internal/idp/serve.go
+++ b/internal/idp/serve.go
@@ -36,7 +36,7 @@ func ServeCmd(ctx context.Context, sqldb *sql.DB, db *DB, issuerURL *url.URL, cl
 		return fmt.Errorf("failed to migrate data: %v", err)
 	}
 
-	oidcHandles, err := initKeysets(ctx, sqldb, g)
+	oidcHandles, err := initKeysets(ctx, sqldb)
 	if err != nil {
 		return fmt.Errorf("initializing keysets: %w", err)
 	}


### PR DESCRIPTION
For running on fly:
* honour their request ID
* use the remote IP header
* force TLS. App should be TLS only, but worth forcing it

Fix key rotation. It wasn't working because the run group was being passed by value, so the "group" it was registered on was never started.