### PR TITLE
Add clients implementation

### DIFF
--- a/cmd/webauthn-oidc-idp/config.go
+++ b/cmd/webauthn-oidc-idp/config.go
@@ -100,9 +100,6 @@ func loadConfig(file []byte) (*config, error) {
 	if err := dec.Decode(cfg); err != nil {
 		return nil, fmt.Errorf("decode config: %w", err)
 	}
-	if len(cfg.Tenants) != 1 {
-		return nil, errors.New("must configure exactly 1 tenant")
-	}
 	var seenHostnames []string
 	for i, tenant := range cfg.Tenants {
 		if tenant.Issuer == "" {

--- a/cmd/webauthn-oidc-idp/config.go
+++ b/cmd/webauthn-oidc-idp/config.go
@@ -11,7 +11,7 @@ import (
 	"slices"
 	"strings"
 
-	o2staticclients "github.com/lstoll/oauth2as/staticclients"
+	"github.com/lstoll/webauthn-oidc-idp/internal/clients"
 	"github.com/lstoll/webauthn-oidc-idp/internal/idp"
 	"github.com/tailscale/hujson"
 )
@@ -22,9 +22,37 @@ type legacyConfig struct {
 	// Database is unused.
 	Database string `json:"database"`
 	Issuers  []struct {
-		URL     string                   `json:"url"`
-		Clients []o2staticclients.Client `json:"clients"`
+		URL     string        `json:"url"`
+		Clients legacyClients `json:"clients"`
 	} `json:"issuers"`
+}
+
+type legacyClients []legacyClient
+
+// legacyClient matches the old client format.
+//
+// ref: https://github.com/lstoll/oauth2ext/blob/989e22bde1f1b12721bf21f7ab50a351ba115da3/core/staticclients/staticclients.go#L58-L80
+type legacyClient struct {
+	// ID is the identifier for this client, corresponds to the client ID.
+	ID string `json:"id" yaml:"id"`
+	// Secrets is a list of valid client secrets for this client. At least
+	// one secret is required, unless the client is Public and uses PKCE.
+	Secrets []string `json:"clientSecrets" yaml:"clientSecrets"`
+	// RedirectURLS is a list of valid redirect URLs for this client. At least
+	// one is required, unless the client is public a PermitLocalhostRedirect is
+	// true. These are an exact match
+	RedirectURLs []string `json:"redirectURLs" yaml:"redirectURLs"`
+	// Public indicates that this client is public. A "public" client is one who
+	// can't keep their credentials confidential.
+	// https://datatracker.ietf.org/doc/html/rfc6749#section-2.1
+	Public bool `json:"public" yaml:"public"`
+	// PermitLocalhostRedirect allows redirects to localhost, if this is a
+	// public client
+	PermitLocalhostRedirect bool `json:"permitLocalhostRedirect" yaml:"permitLocalhostRedirect"`
+	// RequiresPKCE indicates that this client should be required to use PKCE
+	// for the token exchange. This defaults to true for public clients, and
+	// false for non-public clients.
+	RequiresPKCE *bool `json:"requiresPKCE" yaml:"requiresPKCE"`
 }
 
 type config struct {
@@ -44,10 +72,12 @@ type configTenant struct {
 	// It will import the clients from that config. (not yet, they are just
 	// used.). It is currently still required for the client config.
 	ImportConfigPath string `json:"importConfigPath"`
+	// StaticClientsPath is a path to a list of static clients
+	StaticClientsPath string `json:"staticClientsPath"`
 
 	// ImportedClients is the clients imported from the legacy config, filled at
-	// parse time.
-	ImportedClients []o2staticclients.Client `json:"-"`
+	// parse time, and merged with the static clients.
+	Clients *clients.StaticClients `json:"-"`
 	// db connection for the tenant.
 	db *sql.DB `json:"-"`
 	// legacyDB is the database connection for the legacy config
@@ -110,22 +140,80 @@ func loadConfig(file []byte) (*config, error) {
 			return nil, fmt.Errorf("tenant %s must configure exactly 1 issuer", tenant.Issuer)
 		}
 
-		cfg.Tenants[i].ImportedClients = legacyCfg.Issuers[0].Clients
-
 		var validErr error
-		for ii, c := range tenant.ImportedClients {
+		// Convert legacy clients to new format
+		var newClients []clients.Client
+		for ii, c := range legacyCfg.Issuers[0].Clients {
 			if c.ID == "" {
 				validErr = errors.Join(validErr, fmt.Errorf("tenant %s client %d must set clientID", tenant.Issuer, ii))
 			}
 			if len(c.RedirectURLs) == 0 && !c.Public {
 				validErr = errors.Join(validErr, fmt.Errorf("tenant %s client %d requires a redirect URL when not public with localhost permitted", tenant.Issuer, ii))
 			}
-			if len(c.Secrets) == 0 && !c.Public && c.RequiresPKCE != nil && !*c.RequiresPKCE {
-				validErr = errors.Join(validErr, fmt.Errorf("tenant %s client %d requires a client secret when PKCE not required", tenant.Issuer, ii))
+
+			// Build the new client format
+			cl := clients.Client{
+				ID:           c.ID,
+				Secrets:      c.Secrets,
+				RedirectURLs: c.RedirectURLs,
+				Public:       c.Public,
+				// We always expected these to use the override subject, opt-in
+				// by default here, the new config can change that behaviour.
+				UseOverrideSubject: true,
 			}
+
+			// Handle PKCE logic: SkipPKCE is inverted from RequiresPKCE
+			if c.RequiresPKCE != nil {
+				cl.SkipPKCE = !*c.RequiresPKCE
+			} else {
+				// Default behavior: PKCE required for public clients, not for private clients
+				cl.SkipPKCE = !c.Public
+			}
+
+			// Handle localhost redirect for public clients with PermitLocalhostRedirect
+			if c.Public && c.PermitLocalhostRedirect {
+				// Add localhost callback if not already present
+				hasLocalhost := slices.Contains(cl.RedirectURLs, "http://127.0.0.1/callback")
+				if !hasLocalhost {
+					cl.RedirectURLs = append(cl.RedirectURLs, "http://127.0.0.1/callback")
+				}
+			}
+
+			newClients = append(newClients, cl)
 		}
 		if validErr != nil {
 			return nil, validErr
+		}
+
+		cfg.Tenants[i].Clients = &clients.StaticClients{Clients: newClients}
+
+		if cfg.Tenants[i].StaticClientsPath != "" {
+			scb, err := os.ReadFile(cfg.Tenants[i].StaticClientsPath)
+			if err != nil {
+				return nil, fmt.Errorf("tenant %s read staticClientsPath: %w", tenant.Issuer, err)
+			}
+			scb = []byte(os.Expand(string(scb), getenvWithDefault))
+			scb, err = hujson.Standardize(scb)
+			if err != nil {
+				return nil, fmt.Errorf("standardize config: %w", err)
+			}
+
+			var sc clients.StaticClients
+			dec := json.NewDecoder(bytes.NewReader(scb))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&sc); err != nil {
+				return nil, fmt.Errorf("decode config: %w", err)
+			}
+
+			if err := sc.Validate(); err != nil {
+				return nil, fmt.Errorf("tenant %s validate staticClientsPath: %w", tenant.Issuer, err)
+			}
+
+			merged, err := clients.MergeStaticClients(cfg.Tenants[i].Clients, &sc)
+			if err != nil {
+				return nil, fmt.Errorf("tenant %s merge staticClientsPath: %w", tenant.Issuer, err)
+			}
+			cfg.Tenants[i].Clients = merged
 		}
 
 	}

--- a/cmd/webauthn-oidc-idp/main.go
+++ b/cmd/webauthn-oidc-idp/main.go
@@ -167,7 +167,7 @@ func main() {
 		mux := http.NewServeMux()
 
 		for _, tenant := range cfg.Tenants {
-			h, err := idp.NewIDP(ctx, &g, tenant.db, tenant.legacyDB, tenant.issuerURL, tenant.ImportedClients)
+			h, err := idp.NewIDP(ctx, &g, tenant.db, tenant.legacyDB, tenant.issuerURL, tenant.Clients)
 			if err != nil {
 				fatalf("start server: %v", err)
 			}

--- a/cmd/webauthn-oidc-idp/main.go
+++ b/cmd/webauthn-oidc-idp/main.go
@@ -143,9 +143,11 @@ func main() {
 			fatalf("run migrations: %v", err)
 		}
 
-		tenant.legacyDB, err = idp.OpenDB(tenant.ImportDBPath)
-		if err != nil {
-			fatalf("open legacy database for tenant %s at %s: %v", tenant.Issuer, tenant.ImportDBPath, err)
+		if tenant.ImportDBPath != "" {
+			tenant.legacyDB, err = idp.OpenDB(tenant.ImportDBPath)
+			if err != nil {
+				fatalf("open legacy database for tenant %s at %s: %v", tenant.Issuer, tenant.ImportDBPath, err)
+			}
 		}
 
 		if tenant.Issuer == *selectedIssuer {

--- a/cmd/webauthn-oidc-idp/testdata/legacyConfig.json
+++ b/cmd/webauthn-oidc-idp/testdata/legacyConfig.json
@@ -12,6 +12,28 @@
 				{
 					"id": "cli",
 					"public": true
+				},
+				{
+					"id": "public-localhost",
+					"public": true,
+					"permitLocalhostRedirect": true
+				},
+				{
+					"id": "public-localhost-existing",
+					"public": true,
+					"permitLocalhostRedirect": true,
+					"redirectURLs": ["http://127.0.0.1/callback", "https://example.com/callback"]
+				},
+				{
+					"id": "explicit-pkce",
+					"public": true,
+					"requiresPKCE": false
+				},
+				{
+					"id": "explicit-pkce-true",
+					"public": false,
+					"requiresPKCE": true,
+					"redirectURLs": ["https://example.com/callback"]
 				}
 			]
 		}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 	cdpwebauthn "github.com/chromedp/cdproto/webauthn"
 	"github.com/chromedp/chromedp"
-	o2staticclients "github.com/lstoll/oauth2as/staticclients"
 	clitoken "github.com/lstoll/oauth2ext/clitoken"
 	"github.com/lstoll/oauth2ext/oidc"
 	dbpkg "github.com/lstoll/webauthn-oidc-idp/db"
+	"github.com/lstoll/webauthn-oidc-idp/internal/clients"
 	"github.com/lstoll/webauthn-oidc-idp/internal/idp"
 	"github.com/lstoll/webauthn-oidc-idp/internal/queries"
 	_ "github.com/mattn/go-sqlite3"
@@ -100,12 +100,14 @@ func TestE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	clients := []o2staticclients.Client{
-		{
-			ID:           "test-cli",
-			Secrets:      []string{"public"},
-			Public:       true,
-			RedirectURLs: []string{"http://127.0.0.1/callback"},
+	clients := &clients.StaticClients{
+		Clients: []clients.Client{
+			{
+				ID:           "test-cli",
+				Secrets:      []string{"public"},
+				Public:       true,
+				RedirectURLs: []string{"http://127.0.0.1/callback"},
+			},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-webauthn/webauthn v0.13.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692
+	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728010430-eb7fb8935666
 	github.com/lstoll/oauth2ext v1.0.0-beta.6
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
 	github.com/lstoll/web v0.0.0-20250727132609-68a8d2f7e1ae

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-webauthn/webauthn v0.13.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03
+	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692
 	github.com/lstoll/oauth2ext v1.0.0-beta.6
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
 	github.com/lstoll/web v0.0.0-20250727132609-68a8d2f7e1ae

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03 h1:2qBPCXqv/uRtgQXAJXnEm95wa9wtsYVt14AWwwx29K0=
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692 h1:rlbtO0RxutGNBsIXJEKjnf4mVyc0jF14l6KHIiFDm8k=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
 github.com/lstoll/oauth2ext v1.0.0-beta.6 h1:X5/qH7mjGnFSOff0QWEahnQKcTjuf4eo+c87cGIQJxU=
 github.com/lstoll/oauth2ext v1.0.0-beta.6/go.mod h1:zjIrnJNnDU2cQoGTN3mWc+GgRFxMXA9LphIJ64tqApA=
 github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215 h1:fj/z3BLXwgBJ9oWsrZNbHN98ffwajmKP2JNg+OQjsC8=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03 h1:2qBPC
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692 h1:rlbtO0RxutGNBsIXJEKjnf4mVyc0jF14l6KHIiFDm8k=
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728005340-dd6e1d4d8d31 h1:ZEHtA6ysESC1YbUP6gEgrc9YZ/zh7CB8SbTkadIkphY=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728005340-dd6e1d4d8d31/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728010430-eb7fb8935666 h1:CqeSdBuIBeCfFDWmM4dAgrizIdY9Yir3j50OkvFBfEM=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728010430-eb7fb8935666/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
 github.com/lstoll/oauth2ext v1.0.0-beta.6 h1:X5/qH7mjGnFSOff0QWEahnQKcTjuf4eo+c87cGIQJxU=
 github.com/lstoll/oauth2ext v1.0.0-beta.6/go.mod h1:zjIrnJNnDU2cQoGTN3mWc+GgRFxMXA9LphIJ64tqApA=
 github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215 h1:fj/z3BLXwgBJ9oWsrZNbHN98ffwajmKP2JNg+OQjsC8=

--- a/internal/idp/serve.go
+++ b/internal/idp/serve.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/lstoll/oauth2as"
-	o2staticclients "github.com/lstoll/oauth2as/staticclients"
 	"github.com/lstoll/web"
 	"github.com/lstoll/web/csp"
 	"github.com/lstoll/web/proxyhdrs"
@@ -18,6 +17,7 @@ import (
 	"github.com/lstoll/web/session"
 	"github.com/lstoll/web/session/sqlkv"
 	"github.com/lstoll/webauthn-oidc-idp/internal/auth"
+	"github.com/lstoll/webauthn-oidc-idp/internal/clients"
 	"github.com/lstoll/webauthn-oidc-idp/internal/oidcsvr"
 	"github.com/lstoll/webauthn-oidc-idp/internal/queries"
 	"github.com/lstoll/webauthn-oidc-idp/internal/webcommon"
@@ -25,7 +25,7 @@ import (
 )
 
 // NewIDP creates a new IDP server for the given params.
-func NewIDP(ctx context.Context, g *run.Group, sqldb *sql.DB, db *DB, issuerURL *url.URL, clients []o2staticclients.Client) (http.Handler, error) {
+func NewIDP(ctx context.Context, g *run.Group, sqldb *sql.DB, db *DB, issuerURL *url.URL, clients *clients.StaticClients) (http.Handler, error) {
 	if err := migrateData(ctx, db, sqldb); err != nil {
 		return nil, fmt.Errorf("failed to migrate data: %v", err)
 	}
@@ -134,29 +134,11 @@ func NewIDP(ctx context.Context, g *run.Group, sqldb *sql.DB, db *DB, issuerURL 
 		Queries: queries.New(sqldb),
 	}
 
-	var o2clients []o2staticclients.Client
-	for _, c := range clients {
-		o2c := o2staticclients.Client{
-			ID:           c.ID,
-			Secrets:      c.Secrets,
-			RedirectURLs: c.RedirectURLs,
-			Public:       c.Public,
-			RequiresPKCE: c.RequiresPKCE,
-		}
-		// TODO - this is a temp hack, we should update clients to be explicit.
-		if c.Public {
-			o2c.RedirectURLs = append(o2c.RedirectURLs, "http://127.0.0.1/callback")
-		}
-		o2clients = append(o2clients, o2c)
-	}
-
 	oauth2asConfig := oauth2as.Config{
 		Issuer:  issuerURL.String(),
 		Storage: oidcsvr.NewSQLiteStorage(sqldb),
-		Clients: &o2staticclients.Clients{
-			Clients: o2clients,
-		},
-		Keyset: oidcHandles,
+		Clients: clients,
+		Keyset:  oidcHandles,
 
 		TokenHandler:    oidchHandlers.TokenHandler,
 		UserinfoHandler: oidchHandlers.UserinfoHandler,

--- a/internal/idp/serve.go
+++ b/internal/idp/serve.go
@@ -133,6 +133,7 @@ func NewIDP(ctx context.Context, g *run.Group, sqldb *sql.DB, legacyDB *DB, issu
 	oidchHandlers := &oidcsvr.Handlers{
 		Issuer:  issuerURL.String(),
 		Queries: queries.New(sqldb),
+		Clients: clients,
 	}
 
 	oauth2asConfig := oauth2as.Config{

--- a/internal/idp/webauthn_manager.go
+++ b/internal/idp/webauthn_manager.go
@@ -37,7 +37,6 @@ type pendingWebauthnEnrollment struct {
 }
 
 type webauthnManager struct {
-	db       *DB
 	queries  *queries.Queries
 	webauthn *webauthn.WebAuthn
 }


### PR DESCRIPTION
The shared staticclients implementation was dropped in https://github.com/lstoll/oauth2as/pull/29 , it's not really a one-size-fits-all thing.

Add one locally to the app, that can support things like the need for override subjects to atone for the sins of my past. 

The legacy parser was partially broken in #56 because of the shared implementation, now it's under our control the legacy config file clients load as expected again.