### PR TITLE
Per-client token expiration, multi-algorithm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ fly.toml
 config.fly.json
 legacy-config.fly.json
 Dockerfile.fly
+/clients.fly.hujson

--- a/cmd/webauthn-oidc-idp/config.go
+++ b/cmd/webauthn-oidc-idp/config.go
@@ -157,6 +157,8 @@ func loadConfig(file []byte) (*config, error) {
 				// We always expected these to use the override subject, opt-in
 				// by default here, the new config can change that behaviour.
 				UseOverrideSubject: true,
+				// we historically used RS256 for tokens, so default to that.
+				UseRS256: true,
 			}
 
 			// Handle PKCE logic: SkipPKCE is inverted from RequiresPKCE

--- a/cmd/webauthn-oidc-idp/config_test.go
+++ b/cmd/webauthn-oidc-idp/config_test.go
@@ -24,12 +24,14 @@ func TestLoadConfig(t *testing.T) {
 							RedirectURLs:       []string{"http://localhost:8084/callback"},
 							SkipPKCE:           true, // Private client: PKCE not required
 							UseOverrideSubject: true,
+							UseRS256:           true,
 						},
 						{
 							ID:                 "cli",
 							Public:             true,
 							SkipPKCE:           false, // Public client: PKCE required
 							UseOverrideSubject: true,
+							UseRS256:           true,
 						},
 						{
 							ID:                 "public-localhost",
@@ -37,6 +39,7 @@ func TestLoadConfig(t *testing.T) {
 							SkipPKCE:           false,                                 // Public client: PKCE required
 							RedirectURLs:       []string{"http://127.0.0.1/callback"}, // Added due to PermitLocalhostRedirect
 							UseOverrideSubject: true,
+							UseRS256:           true,
 						},
 						{
 							ID:                 "public-localhost-existing",
@@ -44,12 +47,14 @@ func TestLoadConfig(t *testing.T) {
 							SkipPKCE:           false,                                                                 // Public client: PKCE required
 							RedirectURLs:       []string{"http://127.0.0.1/callback", "https://example.com/callback"}, // Existing localhost not duplicated
 							UseOverrideSubject: true,
+							UseRS256:           true,
 						},
 						{
 							ID:                 "explicit-pkce",
 							Public:             true,
 							SkipPKCE:           true, // Explicitly set to false, so SkipPKCE = !false = true
 							UseOverrideSubject: true,
+							UseRS256:           true,
 						},
 						{
 							ID:                 "explicit-pkce-true",
@@ -57,6 +62,7 @@ func TestLoadConfig(t *testing.T) {
 							SkipPKCE:           false, // Explicitly set to true, so SkipPKCE = !true = false
 							RedirectURLs:       []string{"https://example.com/callback"},
 							UseOverrideSubject: true,
+							UseRS256:           true,
 						},
 					},
 				},

--- a/cmd/webauthn-oidc-idp/main.go
+++ b/cmd/webauthn-oidc-idp/main.go
@@ -88,6 +88,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  enroll-user  Enroll a user into the system\n")
 		fmt.Fprintf(os.Stderr, "  add-credential  Add a credential to a user\n")
 		fmt.Fprintf(os.Stderr, "  list-credentials  List credentials for a user\n")
+		fmt.Fprintf(os.Stderr, "  validate-config  Load and validate the config\n")
 		os.Exit(1)
 	}
 
@@ -116,6 +117,12 @@ func main() {
 			fatalf("load config file %s: %v", *configFile, err)
 		}
 		cfg = c
+	}
+
+	if subcommand == "validate-config" {
+		// we can stop here.
+		fmt.Fprintln(os.Stdout, "config is valid")
+		os.Exit(0)
 	}
 
 	if len(cfg.Tenants) != 1 {

--- a/db/migrations/2025-08-03-1919_tokens_are_bytes.sql
+++ b/db/migrations/2025-08-03-1919_tokens_are_bytes.sql
@@ -1,0 +1,33 @@
+-- Drop existing indexes on the columns we're changing
+DROP INDEX idx_grants_auth_code;
+DROP INDEX idx_grants_refresh_token;
+
+-- SQLite doesn't support dropping UNIQUE constraints directly, so we need to recreate the table
+-- Create new table with BLOB columns included
+CREATE TABLE grants_new (
+    id TEXT PRIMARY KEY, -- UUID for the grant
+    auth_code BLOB, -- Authorization code, if present
+    refresh_token BLOB, -- Refresh token, if present
+    user_id TEXT NOT NULL, -- User ID that was granted access
+    client_id TEXT NOT NULL, -- Client ID that was granted access
+    granted_scopes TEXT NOT NULL, -- JSON array of granted scopes
+    request_data BLOB NOT NULL, -- JSON marshaled request data
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, -- When the grant was created
+    expires_at DATETIME NOT NULL -- When the grant expires
+);
+
+-- Copy data from old table to new table (excluding the columns we're changing)
+INSERT INTO grants_new SELECT id, NULL, NULL, user_id, client_id, granted_scopes, request_data, created_at, expires_at FROM grants;
+
+-- Drop the old table
+DROP TABLE grants;
+
+-- Rename new table to original name
+ALTER TABLE grants_new RENAME TO grants;
+
+-- Recreate all indexes
+CREATE INDEX idx_grants_auth_code ON grants (auth_code);
+CREATE INDEX idx_grants_refresh_token ON grants (refresh_token);
+CREATE INDEX idx_grants_expires_at ON grants (expires_at);
+CREATE INDEX idx_grants_user_id ON grants (user_id);
+CREATE INDEX idx_grants_client_id ON grants (client_id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -39,10 +39,10 @@ CREATE TABLE web_sessions (
     expires_at TEXT NOT NULL
 );
 
-CREATE TABLE grants (
+CREATE TABLE "grants" (
     id TEXT PRIMARY KEY, -- UUID for the grant
-    auth_code TEXT UNIQUE, -- Authorization code, if present
-    refresh_token TEXT UNIQUE, -- Refresh token, if present
+    auth_code BLOB, -- Authorization code, if present
+    refresh_token BLOB, -- Refresh token, if present
     user_id TEXT NOT NULL, -- User ID that was granted access
     client_id TEXT NOT NULL, -- Client ID that was granted access
     granted_scopes TEXT NOT NULL, -- JSON array of granted scopes

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-webauthn/webauthn v0.13.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728010430-eb7fb8935666
+	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803171739-53107b53a896
 	github.com/lstoll/oauth2ext v1.0.0-beta.6
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
 	github.com/lstoll/web v0.0.0-20250727132609-68a8d2f7e1ae

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/go-webauthn/webauthn v0.13.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803171739-53107b53a896
-	github.com/lstoll/oauth2ext v1.0.0-beta.6
+	github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803195333-01fe433b6f85
+	github.com/lstoll/oauth2ext v1.0.0-beta.6.0.20250803185422-232422a2b402
 	github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215
 	github.com/lstoll/web v0.0.0-20250727132609-68a8d2f7e1ae
 	github.com/mattn/go-sqlite3 v1.14.29

--- a/go.sum
+++ b/go.sum
@@ -42,14 +42,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03 h1:2qBPCXqv/uRtgQXAJXnEm95wa9wtsYVt14AWwwx29K0=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250727220936-ff51b3fdec03/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692 h1:rlbtO0RxutGNBsIXJEKjnf4mVyc0jF14l6KHIiFDm8k=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728003529-2ee9f0d9e692/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728005340-dd6e1d4d8d31 h1:ZEHtA6ysESC1YbUP6gEgrc9YZ/zh7CB8SbTkadIkphY=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728005340-dd6e1d4d8d31/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728010430-eb7fb8935666 h1:CqeSdBuIBeCfFDWmM4dAgrizIdY9Yir3j50OkvFBfEM=
-github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250728010430-eb7fb8935666/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803171739-53107b53a896 h1:/29Imac8rzjRqqVVnqUCZ3XKwZ8o2vAuPJRBq3rogro=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803171739-53107b53a896/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
 github.com/lstoll/oauth2ext v1.0.0-beta.6 h1:X5/qH7mjGnFSOff0QWEahnQKcTjuf4eo+c87cGIQJxU=
 github.com/lstoll/oauth2ext v1.0.0-beta.6/go.mod h1:zjIrnJNnDU2cQoGTN3mWc+GgRFxMXA9LphIJ64tqApA=
 github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215 h1:fj/z3BLXwgBJ9oWsrZNbHN98ffwajmKP2JNg+OQjsC8=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,14 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803171739-53107b53a896 h1:/29Imac8rzjRqqVVnqUCZ3XKwZ8o2vAuPJRBq3rogro=
 github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803171739-53107b53a896/go.mod h1:nPM5U0xZd4IdP23RT8UWQjx0seT0tnNxhxz+FaT+448=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803185833-073260eab743 h1:cKKM/AcgM9yLAxo84U1A011PDDXldCqPnwajkegbJl8=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803185833-073260eab743/go.mod h1:2r5D2b9yCIqOMYgnMAzAnO+ipQYMLHQNQ2dc3pjgfow=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803195333-01fe433b6f85 h1:5qo9aeGALrEaj5j9aoqq/TFjQx16KwA8j3llo8ylflM=
+github.com/lstoll/oauth2as v1.0.0-alpha.1.0.20250803195333-01fe433b6f85/go.mod h1:2r5D2b9yCIqOMYgnMAzAnO+ipQYMLHQNQ2dc3pjgfow=
 github.com/lstoll/oauth2ext v1.0.0-beta.6 h1:X5/qH7mjGnFSOff0QWEahnQKcTjuf4eo+c87cGIQJxU=
 github.com/lstoll/oauth2ext v1.0.0-beta.6/go.mod h1:zjIrnJNnDU2cQoGTN3mWc+GgRFxMXA9LphIJ64tqApA=
+github.com/lstoll/oauth2ext v1.0.0-beta.6.0.20250803185422-232422a2b402 h1:fhjPrLiendoLwbyRa6Ju15Fd7lARycjdQcgrea6BAnM=
+github.com/lstoll/oauth2ext v1.0.0-beta.6.0.20250803185422-232422a2b402/go.mod h1:zjIrnJNnDU2cQoGTN3mWc+GgRFxMXA9LphIJ64tqApA=
 github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215 h1:fj/z3BLXwgBJ9oWsrZNbHN98ffwajmKP2JNg+OQjsC8=
 github.com/lstoll/tinkrotate v0.0.0-20250628134202-3c7c777eb215/go.mod h1:x9r6po7qyhQIvVUZSQjs0VwsCfR1sgg9xAPpvyPkfGE=
 github.com/lstoll/web v0.0.0-20250727132609-68a8d2f7e1ae h1:+GUq5zulK1lTSgem32aYuuc+ZmmXZDjE8L1zZxWZTPE=

--- a/internal/clients/static.go
+++ b/internal/clients/static.go
@@ -54,6 +54,9 @@ type Client struct {
 	// UseOverrideSubject indicates that this client should use the override
 	// subject for tokens/userinfo, rather than the user's ID
 	UseOverrideSubject bool `json:"useOverrideSubject"`
+	// UseRS256 indicates that this client should use RS256 for tokens/userinfo,
+	// rather than defaulting to ES256
+	UseRS256 bool `json:"useRS256"`
 }
 
 // GetClient returns the client with the given ID, or nil if it doesn't exist.
@@ -78,6 +81,12 @@ func (c *StaticClients) ClientOpts(_ context.Context, clientID string) ([]oauth2
 			opts := []oauth2as.ClientOpt{}
 			if cl.SkipPKCE {
 				opts = append(opts, oauth2as.ClientOptSkipPKCE())
+			}
+			if cl.UseRS256 {
+				opts = append(opts, oauth2as.ClientOptSigningAlg(oauth2as.SigningAlgRS256))
+			} else {
+				// TODO - we should make the default configurable on oauth2as.Server
+				opts = append(opts, oauth2as.ClientOptSigningAlg(oauth2as.SigningAlgES256))
 			}
 			return opts, nil
 		}

--- a/internal/clients/static.go
+++ b/internal/clients/static.go
@@ -77,7 +77,7 @@ func (c *StaticClients) ClientOpts(_ context.Context, clientID string) ([]oauth2
 		if cl.ID == clientID {
 			opts := []oauth2as.ClientOpt{}
 			if cl.SkipPKCE {
-				opts = append(opts, oauth2as.ClientOptSkipPKCE)
+				opts = append(opts, oauth2as.ClientOptSkipPKCE())
 			}
 			return opts, nil
 		}

--- a/internal/oidcsvr/handlers.go
+++ b/internal/oidcsvr/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/lstoll/oauth2as"
@@ -51,6 +52,11 @@ func (h *Handlers) TokenHandler(ctx context.Context, req *oauth2as.TokenRequest)
 
 	if cl.UseOverrideSubject && user.OverrideSubject.Valid {
 		resp.OverrideIDSubject = user.OverrideSubject.String
+	}
+
+	if cl.ParsedTokenValidity > 0 {
+		resp.AccessTokenExpiry = time.Now().Add(cl.ParsedTokenValidity)
+		resp.IDTokenExpiry = time.Now().Add(cl.ParsedTokenValidity)
 	}
 
 	return resp, nil

--- a/internal/oidcsvr/handlers.go
+++ b/internal/oidcsvr/handlers.go
@@ -21,9 +21,9 @@ type Handlers struct {
 }
 
 func (h *Handlers) TokenHandler(ctx context.Context, req *oauth2as.TokenRequest) (*oauth2as.TokenResponse, error) {
-	slog.Info("token handler", "clientID", req.Grant.ClientID, "scopes", req.Grant.GrantedScopes)
+	slog.Info("token handler", "clientID", req.ClientID, "scopes", req.GrantedScopes)
 
-	userUUID, err := uuid.Parse(req.Grant.UserID)
+	userUUID, err := uuid.Parse(req.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("parse user ID: %w", err)
 	}
@@ -33,9 +33,9 @@ func (h *Handlers) TokenHandler(ctx context.Context, req *oauth2as.TokenRequest)
 		return nil, fmt.Errorf("get user: %w", err)
 	}
 
-	cl, ok := h.Clients.GetClient(req.Grant.ClientID)
+	cl, ok := h.Clients.GetClient(req.ClientID)
 	if !ok {
-		return nil, fmt.Errorf("client %s not found", req.Grant.ClientID)
+		return nil, fmt.Errorf("client %s not found", req.ClientID)
 	}
 
 	resp := &oauth2as.TokenResponse{

--- a/internal/oidcsvr/sqlite_storage.go
+++ b/internal/oidcsvr/sqlite_storage.go
@@ -37,14 +37,12 @@ func (s *SQLiteStorage) CreateGrant(ctx context.Context, grant *oauth2as.StoredG
 		return fmt.Errorf("marshal granted scopes: %w", err)
 	}
 
-	var authCode, refreshToken sql.NullString
-	if grant.AuthCode != nil && *grant.AuthCode != "" {
-		authCode.String = *grant.AuthCode
-		authCode.Valid = true
+	var authCode, refreshToken []byte
+	if len(grant.AuthCode) > 0 {
+		authCode = grant.AuthCode
 	}
-	if grant.RefreshToken != nil && *grant.RefreshToken != "" {
-		refreshToken.String = *grant.RefreshToken
-		refreshToken.Valid = true
+	if len(grant.RefreshToken) > 0 {
+		refreshToken = grant.RefreshToken
 	}
 
 	params := queries.CreateGrantParams{
@@ -73,14 +71,12 @@ func (s *SQLiteStorage) UpdateGrant(ctx context.Context, grant *oauth2as.StoredG
 		return fmt.Errorf("marshal granted scopes: %w", err)
 	}
 
-	var authCode, refreshToken sql.NullString
-	if grant.AuthCode != nil && *grant.AuthCode != "" {
-		authCode.String = *grant.AuthCode
-		authCode.Valid = true
+	var authCode, refreshToken []byte
+	if len(grant.AuthCode) > 0 {
+		authCode = grant.AuthCode
 	}
-	if grant.RefreshToken != nil && *grant.RefreshToken != "" {
-		refreshToken.String = *grant.RefreshToken
-		refreshToken.Valid = true
+	if len(grant.RefreshToken) > 0 {
+		refreshToken = grant.RefreshToken
 	}
 
 	params := queries.UpdateGrantParams{
@@ -116,9 +112,8 @@ func (s *SQLiteStorage) GetGrant(ctx context.Context, id uuid.UUID) (*oauth2as.S
 }
 
 // GetGrantByAuthCode retrieves a grant by authorization code
-func (s *SQLiteStorage) GetGrantByAuthCode(ctx context.Context, authCode string) (*oauth2as.StoredGrant, error) {
-	nullAuthCode := sql.NullString{String: authCode, Valid: true}
-	grant, err := s.queries.GetGrantByAuthCode(ctx, nullAuthCode)
+func (s *SQLiteStorage) GetGrantByAuthCode(ctx context.Context, authCode []byte) (*oauth2as.StoredGrant, error) {
+	grant, err := s.queries.GetGrantByAuthCode(ctx, authCode)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -130,9 +125,8 @@ func (s *SQLiteStorage) GetGrantByAuthCode(ctx context.Context, authCode string)
 }
 
 // GetGrantByRefreshToken retrieves a grant by refresh token
-func (s *SQLiteStorage) GetGrantByRefreshToken(ctx context.Context, refreshToken string) (*oauth2as.StoredGrant, error) {
-	nullRefreshToken := sql.NullString{String: refreshToken, Valid: true}
-	grant, err := s.queries.GetGrantByRefreshToken(ctx, nullRefreshToken)
+func (s *SQLiteStorage) GetGrantByRefreshToken(ctx context.Context, refreshToken []byte) (*oauth2as.StoredGrant, error) {
+	grant, err := s.queries.GetGrantByRefreshToken(ctx, refreshToken)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -165,11 +159,11 @@ func (s *SQLiteStorage) convertGrant(grant queries.Grant) (*oauth2as.StoredGrant
 		ExpiresAt:     grant.ExpiresAt,
 	}
 
-	if grant.AuthCode.Valid {
-		storedGrant.AuthCode = &grant.AuthCode.String
+	if len(grant.AuthCode) > 0 {
+		storedGrant.AuthCode = grant.AuthCode
 	}
-	if grant.RefreshToken.Valid {
-		storedGrant.RefreshToken = &grant.RefreshToken.String
+	if len(grant.RefreshToken) > 0 {
+		storedGrant.RefreshToken = grant.RefreshToken
 	}
 
 	return storedGrant, nil

--- a/internal/queries/grants.sql.go
+++ b/internal/queries/grants.sql.go
@@ -7,7 +7,6 @@ package queries
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	"github.com/google/uuid"
@@ -29,8 +28,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 
 type CreateGrantParams struct {
 	ID            uuid.UUID
-	AuthCode      sql.NullString
-	RefreshToken  sql.NullString
+	AuthCode      []byte
+	RefreshToken  []byte
 	UserID        string
 	ClientID      string
 	GrantedScopes string
@@ -90,7 +89,7 @@ FROM grants
 WHERE auth_code = ? AND expires_at > datetime('now')
 `
 
-func (q *Queries) GetGrantByAuthCode(ctx context.Context, authCode sql.NullString) (Grant, error) {
+func (q *Queries) GetGrantByAuthCode(ctx context.Context, authCode []byte) (Grant, error) {
 	row := q.db.QueryRowContext(ctx, getGrantByAuthCode, authCode)
 	var i Grant
 	err := row.Scan(
@@ -113,7 +112,7 @@ FROM grants
 WHERE refresh_token = ? AND expires_at > datetime('now')
 `
 
-func (q *Queries) GetGrantByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Grant, error) {
+func (q *Queries) GetGrantByRefreshToken(ctx context.Context, refreshToken []byte) (Grant, error) {
 	row := q.db.QueryRowContext(ctx, getGrantByRefreshToken, refreshToken)
 	var i Grant
 	err := row.Scan(
@@ -137,8 +136,8 @@ WHERE id = ?
 `
 
 type UpdateGrantParams struct {
-	AuthCode      sql.NullString
-	RefreshToken  sql.NullString
+	AuthCode      []byte
+	RefreshToken  []byte
 	UserID        string
 	ClientID      string
 	GrantedScopes string

--- a/internal/queries/models.go
+++ b/internal/queries/models.go
@@ -22,8 +22,8 @@ type Credential struct {
 
 type Grant struct {
 	ID            uuid.UUID
-	AuthCode      sql.NullString
-	RefreshToken  sql.NullString
+	AuthCode      []byte
+	RefreshToken  []byte
 	UserID        string
 	ClientID      string
 	GrantedScopes string


### PR DESCRIPTION
Fixups for some upstream changes.

Add support for multi-algorithm tokens, default to ES256. Legacy clients still get RS256 as per today, new clients have to opt in to RS256.

For new clients, allow setting per-client token expiration. This allows balancing a short-lived default, with some things that are fine with a long expiration.