### PR TITLE
Move keysets to bolt storage

### DIFF
--- a/internal/idp/keyset.go
+++ b/internal/idp/keyset.go
@@ -2,7 +2,6 @@ package idp
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -14,7 +13,7 @@ import (
 	"lds.li/oauth2ext/oauth2as"
 	"lds.li/tinkrotate"
 	tinkrotatev1 "lds.li/tinkrotate/proto/tinkrotate/v1"
-	"lds.li/tinkrotate/sqlstore"
+	"lds.li/webauthn-oidc-idp/internal/storage"
 )
 
 type Keyset struct {
@@ -48,14 +47,8 @@ var (
 	}
 )
 
-func initKeysets(ctx context.Context, db *sql.DB) (oidcKeyset *KeysetSigner, _ error) {
-	store, err := sqlstore.NewSQLStore(db, &sqlstore.SQLStoreOptions{
-		Dialect:   sqlstore.SQLDialectSQLite,
-		TableName: "tink_keysets",
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create store: %w", err)
-	}
+func initKeysets(ctx context.Context, state *storage.State) (oidcKeyset *KeysetSigner, _ error) {
+	store := storage.NewKeysetStore(state)
 
 	autoRotator, err := tinkrotate.NewAutoRotator(store, 10*time.Minute, &tinkrotate.AutoRotatorOpts{
 		ProvisionPolicies: map[string]*tinkrotatev1.RotationPolicy{

--- a/internal/idp/serve.go
+++ b/internal/idp/serve.go
@@ -132,7 +132,7 @@ func (c *ServeCmd) Run(ctx context.Context, config *config.Config, db *sql.DB) e
 
 // NewIDP creates a new IDP server for the given params.
 func NewIDP(ctx context.Context, g *run.Group, cfg *config.Config, credStore *jsonfile.JSONFile[storage.CredentialStore], state *storage.State, sqldb *sql.DB, issuerURL *url.URL, clients *clients.MultiClients) (http.Handler, error) {
-	oidcHandles, err := initKeysets(ctx, sqldb)
+	oidcHandles, err := initKeysets(ctx, state)
 	if err != nil {
 		return nil, fmt.Errorf("initializing keysets: %w", err)
 	}

--- a/internal/storage/state.go
+++ b/internal/storage/state.go
@@ -28,6 +28,9 @@ func NewState(path string) (*State, error) {
 		if _, err := tx.CreateBucketIfNotExists([]byte(bucketRefreshTokens)); err != nil {
 			return fmt.Errorf("create refresh tokens bucket: %w", err)
 		}
+		if _, err := tx.CreateBucketIfNotExists([]byte(bucketKeysets)); err != nil {
+			return fmt.Errorf("create keysets bucket: %w", err)
+		}
 		return nil
 	}); err != nil {
 		db.Close()

--- a/internal/storage/state_keysets.go
+++ b/internal/storage/state_keysets.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/tink-crypto/tink-go/v2/insecurecleartextkeyset"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	bolt "go.etcd.io/bbolt"
+	"google.golang.org/protobuf/proto"
+	"lds.li/tinkrotate"
+	tinkrotatev1 "lds.li/tinkrotate/proto/tinkrotate/v1"
+)
+
+var _ tinkrotate.ManagedStore = (*KeysetStore)(nil)
+
+const (
+	// Bucket name for keyset storage
+	bucketKeysets = "keysets"
+)
+
+// KeysetStore implements tinkrotate.ManagedStore using BoltDB
+type KeysetStore struct {
+	db *bolt.DB
+}
+
+// NewKeysetStore creates a new KeysetStore from a State instance
+func NewKeysetStore(state *State) *KeysetStore {
+	return &KeysetStore{db: state.db}
+}
+
+// storedKeyset represents a keyset stored in BoltDB
+type storedKeyset struct {
+	Handle   []byte `json:"handle"`
+	Metadata []byte `json:"metadata"` // protobuf marshaled metadata
+	Version  int64  `json:"version"`
+}
+
+// GetHandle returns the handle for the given keyset name.
+func (k *KeysetStore) GetHandle(ctx context.Context, keysetName string) (*keyset.Handle, error) {
+	result, err := k.ReadKeysetAndMetadata(ctx, keysetName)
+	if err != nil {
+		return nil, err
+	}
+	return result.Handle, nil
+}
+
+// GetPublicHandle returns the handle for the given keyset name, with only
+// the public key material.
+func (k *KeysetStore) GetPublicHandle(ctx context.Context, keysetName string) (*keyset.Handle, error) {
+	handle, err := k.GetHandle(ctx, keysetName)
+	if err != nil {
+		return nil, err
+	}
+	return handle.Public()
+}
+
+// ReadKeysetAndMetadata reads a keyset and its metadata from the store.
+func (k *KeysetStore) ReadKeysetAndMetadata(ctx context.Context, keysetName string) (*tinkrotate.ReadResult, error) {
+	var result *tinkrotate.ReadResult
+	var notFound bool
+	err := k.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketKeysets))
+		if bucket == nil {
+			notFound = true
+			return nil
+		}
+
+		data := bucket.Get([]byte(keysetName))
+		if data == nil {
+			notFound = true
+			return nil
+		}
+
+		var stored storedKeyset
+		if err := json.Unmarshal(data, &stored); err != nil {
+			return fmt.Errorf("unmarshal keyset: %w", err)
+		}
+
+		reader := keyset.NewBinaryReader(bytes.NewReader(stored.Handle))
+		handle, err := insecurecleartextkeyset.Read(reader)
+		if err != nil {
+			return fmt.Errorf("read keyset handle: %w", err)
+		}
+
+		metadata := &tinkrotatev1.KeyRotationMetadata{}
+		if err := proto.Unmarshal(stored.Metadata, metadata); err != nil {
+			return fmt.Errorf("unmarshal metadata: %w", err)
+		}
+
+		result = &tinkrotate.ReadResult{
+			Handle:   handle,
+			Metadata: metadata,
+			Context:  stored.Version,
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if notFound {
+		return &tinkrotate.ReadResult{Context: int64(0)}, tinkrotate.ErrKeysetNotFound
+	}
+
+	return result, nil
+}
+
+// WriteKeysetAndMetadata writes a keyset and its metadata to the store.
+func (k *KeysetStore) WriteKeysetAndMetadata(ctx context.Context, keysetName string, handle *keyset.Handle, metadata *tinkrotatev1.KeyRotationMetadata, expectedContext any) error {
+	if handle == nil || metadata == nil {
+		return errors.New("handle and metadata cannot be nil for writing")
+	}
+
+	metadataData, err := proto.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("marshal metadata protobuf: %w", err)
+	}
+
+	keysetBuf := new(bytes.Buffer)
+	if err := insecurecleartextkeyset.Write(handle, keyset.NewBinaryWriter(keysetBuf)); err != nil {
+		return fmt.Errorf("write cleartext keyset handle for %q: %w", keysetName, err)
+	}
+
+	return k.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketKeysets))
+		if bucket == nil {
+			return fmt.Errorf("keysets bucket does not exist")
+		}
+
+		existingData := bucket.Get([]byte(keysetName))
+		var newVersion int64
+
+		if expectedContext == nil {
+			// Insert: expect keyset to not exist
+			if existingData != nil {
+				return tinkrotate.ErrOptimisticLockFailed
+			}
+			newVersion = 1
+		} else {
+			// Update: verify version matches
+			expectedVersion, ok := expectedContext.(int64)
+			if !ok {
+				return fmt.Errorf("invalid expectedContext type: expected int64, got %T", expectedContext)
+			}
+
+			if existingData == nil {
+				return tinkrotate.ErrOptimisticLockFailed
+			}
+
+			var existing storedKeyset
+			if err := json.Unmarshal(existingData, &existing); err != nil {
+				return fmt.Errorf("unmarshal existing keyset: %w", err)
+			}
+
+			if existing.Version != expectedVersion {
+				return tinkrotate.ErrOptimisticLockFailed
+			}
+
+			newVersion = expectedVersion + 1
+		}
+
+		stored := storedKeyset{
+			Handle:   keysetBuf.Bytes(),
+			Metadata: metadataData,
+			Version:  newVersion,
+		}
+
+		data, err := json.Marshal(stored)
+		if err != nil {
+			return fmt.Errorf("marshal stored keyset: %w", err)
+		}
+
+		if err := bucket.Put([]byte(keysetName), data); err != nil {
+			return fmt.Errorf("store keyset: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// ForEachKeyset calls fn for each keyset name in the store.
+func (k *KeysetStore) ForEachKeyset(ctx context.Context, fn func(keysetName string) error) error {
+	return k.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketKeysets))
+		if bucket == nil {
+			return nil // No bucket means no keysets
+		}
+
+		return bucket.ForEach(func(k, v []byte) error {
+			return fn(string(k))
+		})
+	})
+}

--- a/internal/storage/state_keysets_test.go
+++ b/internal/storage/state_keysets_test.go
@@ -1,0 +1,239 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	"lds.li/tinkrotate"
+	tinkrotatev1 "lds.li/tinkrotate/proto/tinkrotate/v1"
+)
+
+func TestKeysetStore(t *testing.T) {
+	// Create a temporary file for the BoltDB database
+	tmpfile, err := os.CreateTemp("", "test-keysets-*.db")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+
+	// Create a new State instance
+	state, err := NewState(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("failed to create state: %v", err)
+	}
+	defer state.db.Close()
+
+	// Create a KeysetStore
+	store := NewKeysetStore(state)
+
+	// Create a test keyset handle
+	handle, err := keyset.NewHandle(jwt.RS256_2048_F4_Key_Template())
+	if err != nil {
+		t.Fatalf("failed to create keyset handle: %v", err)
+	}
+
+	keysetName := "test-keyset"
+	metadata := &tinkrotatev1.KeyRotationMetadata{
+		RotationPolicy: &tinkrotatev1.RotationPolicy{
+			KeyTemplate: jwt.RS256_2048_F4_Key_Template(),
+		},
+	}
+
+	// Test writing a new keyset (insert)
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName, handle, metadata, nil)
+	if err != nil {
+		t.Fatalf("failed to write keyset: %v", err)
+	}
+
+	// Test reading the keyset
+	result, err := store.ReadKeysetAndMetadata(context.Background(), keysetName)
+	if err != nil {
+		t.Fatalf("failed to read keyset: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result to be non-nil")
+	}
+	if result.Handle == nil {
+		t.Fatal("expected handle to be non-nil")
+	}
+	if result.Metadata == nil {
+		t.Fatal("expected metadata to be non-nil")
+	}
+	if result.Metadata.RotationPolicy == nil {
+		t.Error("expected RotationPolicy to be non-nil")
+	}
+	if result.Context != int64(1) {
+		t.Errorf("expected version 1, got %v", result.Context)
+	}
+
+	// Test GetHandle
+	retrievedHandle, err := store.GetHandle(context.Background(), keysetName)
+	if err != nil {
+		t.Fatalf("failed to get handle: %v", err)
+	}
+	if retrievedHandle == nil {
+		t.Fatal("expected handle to be non-nil")
+	}
+
+	// Test GetPublicHandle
+	publicHandle, err := store.GetPublicHandle(context.Background(), keysetName)
+	if err != nil {
+		t.Fatalf("failed to get public handle: %v", err)
+	}
+	if publicHandle == nil {
+		t.Fatal("expected public handle to be non-nil")
+	}
+
+	// Test updating the keyset with correct version (optimistic locking)
+	updatedMetadata := &tinkrotatev1.KeyRotationMetadata{
+		RotationPolicy: &tinkrotatev1.RotationPolicy{
+			KeyTemplate: jwt.ES256Template(),
+		},
+	}
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName, handle, updatedMetadata, int64(1))
+	if err != nil {
+		t.Fatalf("failed to update keyset: %v", err)
+	}
+
+	// Verify update
+	updatedResult, err := store.ReadKeysetAndMetadata(context.Background(), keysetName)
+	if err != nil {
+		t.Fatalf("failed to read updated keyset: %v", err)
+	}
+	if updatedResult.Metadata.RotationPolicy == nil {
+		t.Error("expected RotationPolicy to be non-nil")
+	}
+	if updatedResult.Context != int64(2) {
+		t.Errorf("expected version 2, got %v", updatedResult.Context)
+	}
+
+	// Test optimistic lock failure (wrong version)
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName, handle, updatedMetadata, int64(1))
+	if err != tinkrotate.ErrOptimisticLockFailed {
+		t.Errorf("expected ErrOptimisticLockFailed, got %v", err)
+	}
+
+	// Test reading non-existent keyset
+	_, err = store.ReadKeysetAndMetadata(context.Background(), "non-existent")
+	if err != tinkrotate.ErrKeysetNotFound {
+		t.Errorf("expected ErrKeysetNotFound, got %v", err)
+	}
+
+	// Test ForEachKeyset
+	keysetNames := make(map[string]bool)
+	err = store.ForEachKeyset(context.Background(), func(name string) error {
+		keysetNames[name] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to iterate keysets: %v", err)
+	}
+	if !keysetNames[keysetName] {
+		t.Errorf("expected to find keyset %s in iteration", keysetName)
+	}
+
+	// Test writing another keyset
+	handle2, err := keyset.NewHandle(jwt.ES256Template())
+	if err != nil {
+		t.Fatalf("failed to create second keyset handle: %v", err)
+	}
+	keysetName2 := "test-keyset-2"
+	metadata2 := &tinkrotatev1.KeyRotationMetadata{
+		RotationPolicy: &tinkrotatev1.RotationPolicy{
+			KeyTemplate: jwt.ES256Template(),
+		},
+	}
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName2, handle2, metadata2, nil)
+	if err != nil {
+		t.Fatalf("failed to write second keyset: %v", err)
+	}
+
+	// Verify both keysets are found
+	keysetNames = make(map[string]bool)
+	err = store.ForEachKeyset(context.Background(), func(name string) error {
+		keysetNames[name] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to iterate keysets: %v", err)
+	}
+	if len(keysetNames) != 2 {
+		t.Errorf("expected 2 keysets, got %d", len(keysetNames))
+	}
+	if !keysetNames[keysetName] {
+		t.Errorf("expected to find keyset %s", keysetName)
+	}
+	if !keysetNames[keysetName2] {
+		t.Errorf("expected to find keyset %s", keysetName2)
+	}
+
+	// Test that secrets are preserved (can sign with the handle)
+	signer, err := jwt.NewSigner(retrievedHandle)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	if signer == nil {
+		t.Fatal("expected signer to be non-nil")
+	}
+}
+
+func TestKeysetStoreOptimisticLocking(t *testing.T) {
+	// Create a temporary file for the BoltDB database
+	tmpfile, err := os.CreateTemp("", "test-keysets-lock-*.db")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+
+	// Create a new State instance
+	state, err := NewState(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("failed to create state: %v", err)
+	}
+	defer state.db.Close()
+
+	// Create a KeysetStore
+	store := NewKeysetStore(state)
+
+	// Create a test keyset handle
+	handle, err := keyset.NewHandle(jwt.RS256_2048_F4_Key_Template())
+	if err != nil {
+		t.Fatalf("failed to create keyset handle: %v", err)
+	}
+
+	keysetName := "test-lock"
+	metadata := &tinkrotatev1.KeyRotationMetadata{
+		RotationPolicy: &tinkrotatev1.RotationPolicy{
+			KeyTemplate: jwt.RS256_2048_F4_Key_Template(),
+		},
+	}
+
+	// Insert a keyset
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName, handle, metadata, nil)
+	if err != nil {
+		t.Fatalf("failed to write keyset: %v", err)
+	}
+
+	// Try to insert again (should fail with optimistic lock error)
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName, handle, metadata, nil)
+	if err != tinkrotate.ErrOptimisticLockFailed {
+		t.Errorf("expected ErrOptimisticLockFailed when inserting existing keyset, got %v", err)
+	}
+
+	// Try to update with version 0 (should fail)
+	err = store.WriteKeysetAndMetadata(context.Background(), keysetName, handle, metadata, int64(0))
+	if err != tinkrotate.ErrOptimisticLockFailed {
+		t.Errorf("expected ErrOptimisticLockFailed when updating with version 0, got %v", err)
+	}
+
+	// Try to update non-existent keyset (should fail)
+	err = store.WriteKeysetAndMetadata(context.Background(), "non-existent", handle, metadata, int64(1))
+	if err != tinkrotate.ErrOptimisticLockFailed {
+		t.Errorf("expected ErrOptimisticLockFailed when updating non-existent keyset, got %v", err)
+	}
+}


### PR DESCRIPTION
Continuing the sqlite removal, shift the keysets to be stored in bolt too. No migration added here, can just let them re-generate with a few minutes of wonkiness.