### PR TITLE
Move web sessions to bolt

### DIFF
--- a/internal/idp/serve.go
+++ b/internal/idp/serve.go
@@ -22,7 +22,6 @@ import (
 	"lds.li/web/proxyhdrs"
 	"lds.li/web/requestid"
 	"lds.li/web/session"
-	"lds.li/web/session/sqlkv"
 	"lds.li/webauthn-oidc-idp/internal/adminui"
 	"lds.li/webauthn-oidc-idp/internal/auth"
 	"lds.li/webauthn-oidc-idp/internal/clients"
@@ -137,10 +136,7 @@ func NewIDP(ctx context.Context, g *run.Group, cfg *config.Config, credStore *js
 		return nil, fmt.Errorf("initializing keysets: %w", err)
 	}
 
-	sesskv := sqlkv.New(sqldb, &sqlkv.Opts{
-		TableName: "web_sessions",
-		Dialect:   sqlkv.SQLite,
-	})
+	sesskv := storage.NewSessionKV(state)
 
 	sessionManager, err := session.NewKVManager(sesskv, nil)
 	if err != nil {

--- a/internal/storage/state.go
+++ b/internal/storage/state.go
@@ -31,6 +31,9 @@ func NewState(path string) (*State, error) {
 		if _, err := tx.CreateBucketIfNotExists([]byte(bucketKeysets)); err != nil {
 			return fmt.Errorf("create keysets bucket: %w", err)
 		}
+		if _, err := tx.CreateBucketIfNotExists([]byte(bucketSessions)); err != nil {
+			return fmt.Errorf("create sessions bucket: %w", err)
+		}
 		return nil
 	}); err != nil {
 		db.Close()

--- a/internal/storage/state_keysets_test.go
+++ b/internal/storage/state_keysets_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/tink-crypto/tink-go/v2/jwt"
@@ -12,16 +11,8 @@ import (
 )
 
 func TestKeysetStore(t *testing.T) {
-	// Create a temporary file for the BoltDB database
-	tmpfile, err := os.CreateTemp("", "test-keysets-*.db")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
-
 	// Create a new State instance
-	state, err := NewState(tmpfile.Name())
+	state, err := NewState(t.TempDir() + "/state.bolt")
 	if err != nil {
 		t.Fatalf("failed to create state: %v", err)
 	}
@@ -182,16 +173,8 @@ func TestKeysetStore(t *testing.T) {
 }
 
 func TestKeysetStoreOptimisticLocking(t *testing.T) {
-	// Create a temporary file for the BoltDB database
-	tmpfile, err := os.CreateTemp("", "test-keysets-lock-*.db")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
-
 	// Create a new State instance
-	state, err := NewState(tmpfile.Name())
+	state, err := NewState(t.TempDir() + "/state.bolt")
 	if err != nil {
 		t.Fatalf("failed to create state: %v", err)
 	}

--- a/internal/storage/state_oauth2ext_test.go
+++ b/internal/storage/state_oauth2ext_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -14,16 +13,7 @@ import (
 )
 
 func TestStateOAuth2Storage(t *testing.T) {
-	// Create a temporary file for the BoltDB database
-	tmpfile, err := os.CreateTemp("", "test-state-*.db")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
-
-	// Create a new State instance
-	state, err := NewState(tmpfile.Name())
+	state, err := NewState(t.TempDir() + "/state.bolt")
 	if err != nil {
 		t.Fatalf("failed to create state: %v", err)
 	}

--- a/internal/storage/state_sessions.go
+++ b/internal/storage/state_sessions.go
@@ -1,0 +1,193 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+	"lds.li/web/session"
+)
+
+var _ session.KV = (*SessionKV)(nil)
+
+const (
+	// Bucket name for session storage
+	bucketSessions = "sessions"
+)
+
+// SessionKV implements session.KV using BoltDB
+type SessionKV struct {
+	db *bolt.DB
+}
+
+// NewSessionKV creates a new SessionKV from a State instance
+func NewSessionKV(state *State) *SessionKV {
+	return &SessionKV{db: state.db}
+}
+
+// storedSession represents a session stored in BoltDB
+type storedSession struct {
+	Data      []byte    `json:"data"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// Get retrieves a value by key, checking expiration
+func (s *SessionKV) Get(ctx context.Context, key string) (_ []byte, found bool, _ error) {
+	var data []byte
+	err := s.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketSessions))
+		if bucket == nil {
+			return nil // No bucket means no session
+		}
+
+		sessionData := bucket.Get([]byte(key))
+		if sessionData == nil {
+			return nil // Session not found
+		}
+
+		var stored storedSession
+		if err := json.Unmarshal(sessionData, &stored); err != nil {
+			return fmt.Errorf("unmarshal session: %w", err)
+		}
+
+		// Check expiration
+		if time.Now().After(stored.ExpiresAt) {
+			return nil // Session expired
+		}
+
+		data = stored.Data
+		return nil
+	})
+
+	if err != nil {
+		return nil, false, fmt.Errorf("getting %s: %w", key, err)
+	}
+
+	if data == nil {
+		return nil, false, nil
+	}
+
+	return data, true, nil
+}
+
+// Set stores a key with a given value and expiration time, creating or updating as needed
+func (s *SessionKV) Set(ctx context.Context, key string, expiresAt time.Time, value []byte) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketSessions))
+		if bucket == nil {
+			return fmt.Errorf("sessions bucket does not exist")
+		}
+
+		stored := storedSession{
+			Data:      value,
+			ExpiresAt: expiresAt,
+		}
+
+		data, err := json.Marshal(stored)
+		if err != nil {
+			return fmt.Errorf("marshal session: %w", err)
+		}
+
+		if err := bucket.Put([]byte(key), data); err != nil {
+			return fmt.Errorf("storing session: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// Delete removes a key from the store
+func (s *SessionKV) Delete(ctx context.Context, key string) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketSessions))
+		if bucket == nil {
+			return nil // No bucket means nothing to delete
+		}
+
+		if err := bucket.Delete([]byte(key)); err != nil {
+			return fmt.Errorf("deleting %s: %w", key, err)
+		}
+
+		return nil
+	})
+}
+
+// GC performs garbage collection, removing expired sessions
+func (s *SessionKV) GC(ctx context.Context) (deleted int, _ error) {
+	var count int
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketSessions))
+		if bucket == nil {
+			return nil // No bucket means nothing to clean
+		}
+
+		now := time.Now()
+		toDelete := make([][]byte, 0)
+
+		// First pass: collect expired keys
+		err := bucket.ForEach(func(k, v []byte) error {
+			var stored storedSession
+			if err := json.Unmarshal(v, &stored); err != nil {
+				// If we can't unmarshal, consider it corrupted and delete it
+				toDelete = append(toDelete, k)
+				return nil
+			}
+
+			if now.After(stored.ExpiresAt) {
+				toDelete = append(toDelete, k)
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return fmt.Errorf("iterating sessions: %w", err)
+		}
+
+		// Second pass: delete expired keys
+		for _, key := range toDelete {
+			if err := bucket.Delete(key); err != nil {
+				return fmt.Errorf("deleting expired session: %w", err)
+			}
+			count++
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, fmt.Errorf("gc: %w", err)
+	}
+
+	return count, nil
+}
+
+// RunGC starts a background goroutine that performs garbage collection at regular intervals
+func (s *SessionKV) RunGC(ctx context.Context, interval time.Duration, logger *slog.Logger) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				if logger != nil {
+					logger.InfoContext(ctx, "Garbage collection stopped", "reason", ctx.Err())
+				}
+				return
+			case <-ticker.C:
+				deleted, err := s.GC(ctx)
+				if err != nil {
+					if logger != nil {
+						logger.ErrorContext(ctx, "Garbage collection failed", "error", err)
+					}
+				} else if logger != nil {
+					logger.InfoContext(ctx, "Garbage collection successful", "deleted_sessions", deleted)
+				}
+			}
+		}
+	}()
+}

--- a/internal/storage/state_sessions_test.go
+++ b/internal/storage/state_sessions_test.go
@@ -1,0 +1,211 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSessionKV(t *testing.T) {
+	// Create a new State instance
+	state, err := NewState(t.TempDir() + "/state.bolt")
+	if err != nil {
+		t.Fatalf("failed to create state: %v", err)
+	}
+	defer state.db.Close()
+
+	// Create a SessionKV
+	kv := NewSessionKV(state)
+
+	key := "test-session-key"
+	value := []byte("test-session-value")
+	expiresAt := time.Now().Add(time.Hour)
+
+	// Test Set
+	err = kv.Set(context.Background(), key, expiresAt, value)
+	if err != nil {
+		t.Fatalf("failed to set session: %v", err)
+	}
+
+	// Test Get (should find it)
+	retrievedValue, found, err := kv.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+	if !found {
+		t.Fatal("expected session to be found")
+	}
+	if string(retrievedValue) != string(value) {
+		t.Errorf("expected value %q, got %q", string(value), string(retrievedValue))
+	}
+
+	// Test updating the session
+	newValue := []byte("updated-session-value")
+	newExpiresAt := time.Now().Add(2 * time.Hour)
+	err = kv.Set(context.Background(), key, newExpiresAt, newValue)
+	if err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	// Verify update
+	updatedValue, found, err := kv.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("failed to get updated session: %v", err)
+	}
+	if !found {
+		t.Fatal("expected updated session to be found")
+	}
+	if string(updatedValue) != string(newValue) {
+		t.Errorf("expected updated value %q, got %q", string(newValue), string(updatedValue))
+	}
+
+	// Test Delete
+	err = kv.Delete(context.Background(), key)
+	if err != nil {
+		t.Fatalf("failed to delete session: %v", err)
+	}
+
+	// Verify deletion
+	deletedValue, found, err := kv.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("failed to get deleted session: %v", err)
+	}
+	if found {
+		t.Error("expected session to not be found after deletion")
+	}
+	if deletedValue != nil {
+		t.Errorf("expected nil value, got %q", string(deletedValue))
+	}
+
+	// Test expiration
+	expiredKey := "expired-session"
+	expiredValue := []byte("expired-value")
+	pastExpiresAt := time.Now().Add(-time.Hour) // Expired 1 hour ago
+
+	err = kv.Set(context.Background(), expiredKey, pastExpiresAt, expiredValue)
+	if err != nil {
+		t.Fatalf("failed to set expired session: %v", err)
+	}
+
+	// Should not find expired session
+	expiredRetrieved, found, err := kv.Get(context.Background(), expiredKey)
+	if err != nil {
+		t.Fatalf("failed to get expired session: %v", err)
+	}
+	if found {
+		t.Error("expected expired session to not be found")
+	}
+	if expiredRetrieved != nil {
+		t.Errorf("expected nil value for expired session, got %q", string(expiredRetrieved))
+	}
+}
+
+func TestSessionKVGC(t *testing.T) {
+	// Create a new State instance
+	state, err := NewState(t.TempDir() + "/state.bolt")
+	if err != nil {
+		t.Fatalf("failed to create state: %v", err)
+	}
+	defer state.db.Close()
+
+	// Create a SessionKV
+	kv := NewSessionKV(state)
+
+	// Create some expired sessions
+	expiredKeys := []string{"expired1", "expired2", "expired3"}
+	pastExpiresAt := time.Now().Add(-time.Hour)
+	for _, key := range expiredKeys {
+		err := kv.Set(context.Background(), key, pastExpiresAt, []byte("expired-value"))
+		if err != nil {
+			t.Fatalf("failed to set expired session %s: %v", key, err)
+		}
+	}
+
+	// Create some valid sessions
+	validKeys := []string{"valid1", "valid2"}
+	futureExpiresAt := time.Now().Add(time.Hour)
+	for _, key := range validKeys {
+		err := kv.Set(context.Background(), key, futureExpiresAt, []byte("valid-value"))
+		if err != nil {
+			t.Fatalf("failed to set valid session %s: %v", key, err)
+		}
+	}
+
+	// Run GC
+	deleted, err := kv.GC(context.Background())
+	if err != nil {
+		t.Fatalf("failed to run GC: %v", err)
+	}
+	if deleted != len(expiredKeys) {
+		t.Errorf("expected %d deleted sessions, got %d", len(expiredKeys), deleted)
+	}
+
+	// Verify expired sessions are gone
+	for _, key := range expiredKeys {
+		value, found, err := kv.Get(context.Background(), key)
+		if err != nil {
+			t.Fatalf("failed to get expired session %s: %v", key, err)
+		}
+		if found {
+			t.Errorf("expected expired session %s to be deleted", key)
+		}
+		if value != nil {
+			t.Errorf("expected nil value for expired session %s, got %q", key, string(value))
+		}
+	}
+
+	// Verify valid sessions still exist
+	for _, key := range validKeys {
+		value, found, err := kv.Get(context.Background(), key)
+		if err != nil {
+			t.Fatalf("failed to get valid session %s: %v", key, err)
+		}
+		if !found {
+			t.Errorf("expected valid session %s to still exist", key)
+		}
+		if string(value) != "valid-value" {
+			t.Errorf("expected value 'valid-value' for session %s, got %q", key, string(value))
+		}
+	}
+}
+
+func TestSessionKVMultipleSessions(t *testing.T) {
+	// Create a new State instance
+	state, err := NewState(t.TempDir() + "/state.bolt")
+	if err != nil {
+		t.Fatalf("failed to create state: %v", err)
+	}
+	defer state.db.Close()
+
+	// Create a SessionKV
+	kv := NewSessionKV(state)
+
+	// Create multiple sessions
+	sessions := map[string][]byte{
+		"session1": []byte("value1"),
+		"session2": []byte("value2"),
+		"session3": []byte("value3"),
+	}
+	expiresAt := time.Now().Add(time.Hour)
+
+	for key, value := range sessions {
+		err := kv.Set(context.Background(), key, expiresAt, value)
+		if err != nil {
+			t.Fatalf("failed to set session %s: %v", key, err)
+		}
+	}
+
+	// Verify all sessions exist
+	for key, expectedValue := range sessions {
+		value, found, err := kv.Get(context.Background(), key)
+		if err != nil {
+			t.Fatalf("failed to get session %s: %v", key, err)
+		}
+		if !found {
+			t.Errorf("expected session %s to be found", key)
+		}
+		if string(value) != string(expectedValue) {
+			t.Errorf("expected value %q for session %s, got %q", string(expectedValue), key, string(value))
+		}
+	}
+}


### PR DESCRIPTION
Continuing the migration, move the web session storage to the bolt store too. No migration added, will just start fresh.