### PR TITLE
Make SQLite path optional

### DIFF
--- a/cmd/webauthn-oidc-idp/datamigrate.go
+++ b/cmd/webauthn-oidc-idp/datamigrate.go
@@ -15,6 +15,10 @@ import (
 	"lds.li/webauthn-oidc-idp/internal/storage"
 )
 
+func isMigrationRequired(ctx context.Context, cfg *config.Config) bool {
+	return len(cfg.Users) == 0
+}
+
 func migrateUserData(ctx context.Context, db *sql.DB, cfg *config.Config) error {
 	if len(cfg.Users) > 0 {
 		// all good, no action needed.


### PR DESCRIPTION
All the data types have been moved to the new setup. Make providing a SQLite database optional. If we suspect a migration hasn't taken place (i.e no users in config), it will still fail.