### PR TITLE
Expire logins

### DIFF
--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -17,6 +17,7 @@ const (
 // authSess is the session data for authentication
 type authSess struct {
 	LoggedinUserID uuid.NullUUID
+	ExpiresAt      time.Time
 	Flows          map[string]authSessFlow
 }
 
@@ -37,6 +38,9 @@ func UserIDFromContext(ctx context.Context) (*uuid.UUID, bool) {
 		return nil, false
 	}
 	if !as.LoggedinUserID.Valid {
+		return nil, false
+	}
+	if time.Now().After(as.ExpiresAt) {
 		return nil, false
 	}
 	return &as.LoggedinUserID.UUID, as.LoggedinUserID.Valid


### PR DESCRIPTION
Right now we use a session that is bound to the browser lifetime. If it's keep open for a while, we continue to consider the login as valid without re-authenicating. Keep the cookie bound to the browser life, but implement a cap on how long we consider the login to be valid before re-authenticating. This is configurable, and defaults to 1h.